### PR TITLE
feat: add subtle game explanation text near answer form

### DIFF
--- a/src/app/room/components/PlayingGame.component.tsx
+++ b/src/app/room/components/PlayingGame.component.tsx
@@ -62,7 +62,7 @@ export const PlayingGameView = memo(({ room, currentUserId }: PlayingGameViewPro
       </div>
 
       <div className="mb-6">
-        <div className="flex justify-between items-center mb-3">
+        <div className="flex justify-between items-center mb-1">
           <h3 className="text-lg font-semibold text-gray-900">あなたの回答</h3>
           <button
             onClick={toggleAnswerVisibility}
@@ -90,7 +90,7 @@ export const PlayingGameView = memo(({ room, currentUserId }: PlayingGameViewPro
         </div>
 
         {/* ゲーム説明テキスト */}
-        <p className="text-sm text-gray-500 mb-4">
+        <p className="text-sm text-gray-500 mb-3">
           他の参加者と同じ回答を目指しましょう！
         </p>
 

--- a/src/app/room/components/PlayingGame.component.tsx
+++ b/src/app/room/components/PlayingGame.component.tsx
@@ -89,6 +89,23 @@ export const PlayingGameView = memo(({ room, currentUserId }: PlayingGameViewPro
           </button>
         </div>
 
+        {/* ゲーム説明テキスト */}
+        <div className="bg-blue-50 border-l-4 border-blue-300 p-3 mb-4">
+          <div className="flex items-start">
+            <div className="flex-shrink-0">
+              <svg className="w-4 h-4 text-blue-500 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            </div>
+            <div className="ml-2">
+              <p className="text-sm text-blue-800 leading-relaxed">
+                <span className="font-medium">ゲームの目的：</span>他の参加者と同じ回答を目指しましょう！<br />
+                相手の立場で考えて、みんなが思い浮かべそうな答えを入力してください。
+              </p>
+            </div>
+          </div>
+        </div>
+
         {hasSubmittedAnswer ? (
           <div className="p-4 bg-emerald-50 border border-emerald-200 rounded-lg">
             <p className="text-emerald-800 font-medium">回答済み</p>

--- a/src/app/room/components/PlayingGame.component.tsx
+++ b/src/app/room/components/PlayingGame.component.tsx
@@ -90,21 +90,9 @@ export const PlayingGameView = memo(({ room, currentUserId }: PlayingGameViewPro
         </div>
 
         {/* ゲーム説明テキスト */}
-        <div className="bg-blue-50 border-l-4 border-blue-300 p-3 mb-4">
-          <div className="flex items-start">
-            <div className="flex-shrink-0">
-              <svg className="w-4 h-4 text-blue-500 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-            </div>
-            <div className="ml-2">
-              <p className="text-sm text-blue-800 leading-relaxed">
-                <span className="font-medium">ゲームの目的：</span>他の参加者と同じ回答を目指しましょう！<br />
-                相手の立場で考えて、みんなが思い浮かべそうな答えを入力してください。
-              </p>
-            </div>
-          </div>
-        </div>
+        <p className="text-sm text-gray-500 mb-4">
+          他の参加者と同じ回答を目指しましょう！
+        </p>
 
         {hasSubmittedAnswer ? (
           <div className="p-4 bg-emerald-50 border border-emerald-200 rounded-lg">


### PR DESCRIPTION
## Summary
- Add game explanation text "他の参加者と同じ回答を目指しましょう！" near answer form in playing game screen
- Implement subtle grey text design (text-sm text-gray-500) for unobtrusive user experience
- Position text between "あなたの回答" header and input field with appropriate spacing

Closes #11

## Test plan
- [x] Game explanation text appears on playing game screen
- [x] Text is visually subtle and doesn't interfere with game flow
- [x] Text positioning is close to answer form for better context
- [x] Design maintains consistency with existing UI patterns

🤖 Generated with [Claude Code](https://claude.ai/code)