### PR TITLE
feat: リアクション機能の追加

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -16,6 +16,14 @@ service cloud.firestore {
       allow create: if isValidGameRoundCreation();
       allow update: if isValidGameRoundUpdate();
       allow delete: if false;
+
+      // リアクションサブコレクションのルール
+      match /reactions/{reactionId} {
+        allow read: if true;
+        allow create: if isValidReactionCreation();
+        allow delete: if true; // ラウンド終了時のクリーンアップ用
+        allow update: if false;
+      }
     }
     
     // 回答コレクションのルール
@@ -212,6 +220,19 @@ service cloud.firestore {
             (existing.hasAnswered == false && data.hasAnswered == true));
   }
   
+  function isValidReactionCreation() {
+    let data = request.resource.data;
+    return data.keys().hasAll(['emoji', 'fromUserId', 'fromUserName', 'createdAt']) &&
+           data.keys().hasOnly(['emoji', 'fromUserId', 'fromUserName', 'createdAt']) &&
+           data.emoji is string &&
+           data.emoji.size() >= 1 &&
+           data.fromUserId is string &&
+           data.fromUserId.size() > 0 &&
+           data.fromUserName is string &&
+           data.fromUserName.size() >= 1 &&
+           data.createdAt is timestamp;
+  }
+
   function isValidTopicFeedbackCreation() {
     let data = request.resource.data;
     return data.keys().hasAll(['topicContent', 'userId', 'userName', 'rating', 'createdAt']) &&

--- a/src/app/room/components/ReactionBar.component.tsx
+++ b/src/app/room/components/ReactionBar.component.tsx
@@ -21,7 +21,7 @@ export const ReactionBar = memo(({ displayReactions, sendReaction, cooldown }: R
           >
             <div className="flex flex-col items-center">
               <span className="text-4xl leading-none">{r.emoji}</span>
-              <span className="text-xs text-gray-500 whitespace-nowrap bg-white/60 rounded px-1">{r.fromUserName}</span>
+              <span className="text-[10px] text-gray-500 whitespace-nowrap bg-white/60 rounded px-1">{r.fromUserName}</span>
             </div>
           </div>
         ))}

--- a/src/app/room/components/ReactionBar.component.tsx
+++ b/src/app/room/components/ReactionBar.component.tsx
@@ -1,0 +1,51 @@
+import React, { memo } from "react";
+import { DisplayReaction } from "@/types";
+import { REACTION_EMOJIS } from "@/hooks/useReactions";
+
+interface ReactionBarProps {
+  displayReactions: DisplayReaction[];
+  sendReaction: (_emoji: string) => Promise<void>;
+  cooldown: boolean;
+}
+
+export const ReactionBar = memo(({ displayReactions, sendReaction, cooldown }: ReactionBarProps) => {
+  return (
+    <div className="relative border-t border-gray-100 pt-2 mt-4">
+      {/* フローティングリアクション */}
+      <div className="relative h-20 overflow-hidden pointer-events-none">
+        {displayReactions.map((r) => (
+          <div
+            key={r.displayId}
+            className="absolute bottom-0 animate-reaction-float"
+            style={{ left: `${r.x}%` }}
+          >
+            <div className="flex flex-col items-center">
+              <span className="text-3xl leading-none">{r.emoji}</span>
+              <span className="text-xs text-gray-400 whitespace-nowrap">{r.fromUserName}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* 送信ボタン */}
+      <div className="flex justify-center gap-2 py-2">
+        {REACTION_EMOJIS.map((emoji) => (
+          <button
+            key={emoji}
+            onClick={() => sendReaction(emoji)}
+            disabled={cooldown}
+            className={`text-2xl p-2 rounded-full transition-all select-none ${
+              cooldown
+                ? "opacity-40 cursor-not-allowed"
+                : "hover:bg-gray-100 active:scale-125 cursor-pointer"
+            }`}
+          >
+            {emoji}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+});
+
+ReactionBar.displayName = "ReactionBar";

--- a/src/app/room/components/ReactionBar.component.tsx
+++ b/src/app/room/components/ReactionBar.component.tsx
@@ -10,9 +10,9 @@ interface ReactionBarProps {
 
 export const ReactionBar = memo(({ displayReactions, sendReaction, cooldown }: ReactionBarProps) => {
   return (
-    <div className="relative border-t border-gray-100 pt-2 mt-4">
-      {/* フローティングリアクション */}
-      <div className="relative h-20 overflow-hidden pointer-events-none">
+    <>
+      {/* 全画面フローティングリアクション */}
+      <div className="fixed inset-0 pointer-events-none z-50">
         {displayReactions.map((r) => (
           <div
             key={r.displayId}
@@ -20,31 +20,33 @@ export const ReactionBar = memo(({ displayReactions, sendReaction, cooldown }: R
             style={{ left: `${r.x}%` }}
           >
             <div className="flex flex-col items-center">
-              <span className="text-3xl leading-none">{r.emoji}</span>
-              <span className="text-xs text-gray-400 whitespace-nowrap">{r.fromUserName}</span>
+              <span className="text-4xl leading-none">{r.emoji}</span>
+              <span className="text-xs text-gray-500 whitespace-nowrap bg-white/60 rounded px-1">{r.fromUserName}</span>
             </div>
           </div>
         ))}
       </div>
 
       {/* 送信ボタン */}
-      <div className="flex justify-center gap-2 py-2">
-        {REACTION_EMOJIS.map((emoji) => (
-          <button
-            key={emoji}
-            onClick={() => sendReaction(emoji)}
-            disabled={cooldown}
-            className={`text-2xl p-2 rounded-full transition-all select-none ${
-              cooldown
-                ? "opacity-40 cursor-not-allowed"
-                : "hover:bg-gray-100 active:scale-125 cursor-pointer"
-            }`}
-          >
-            {emoji}
-          </button>
-        ))}
+      <div className="border-t border-gray-100 pt-2 mt-4">
+        <div className="flex justify-center gap-2 py-2">
+          {REACTION_EMOJIS.map((emoji) => (
+            <button
+              key={emoji}
+              onClick={() => sendReaction(emoji)}
+              disabled={cooldown}
+              className={`text-2xl p-2 rounded-full transition-all select-none ${
+                cooldown
+                  ? "opacity-40 cursor-not-allowed"
+                  : "hover:bg-gray-100 active:scale-125 cursor-pointer"
+              }`}
+            >
+              {emoji}
+            </button>
+          ))}
+        </div>
       </div>
-    </div>
+    </>
   );
 });
 

--- a/src/app/room/components/ReactionBar.component.tsx
+++ b/src/app/room/components/ReactionBar.component.tsx
@@ -21,7 +21,7 @@ export const ReactionBar = memo(({ displayReactions, sendReaction, cooldown }: R
           >
             <div className="flex flex-col items-center">
               <span className="text-4xl leading-none">{r.emoji}</span>
-              <span className="text-[10px] text-gray-500 whitespace-nowrap bg-white/60 rounded px-1">{r.fromUserName}</span>
+              <span className="text-[10px] text-gray-500 whitespace-nowrap">{r.fromUserName}</span>
             </div>
           </div>
         ))}

--- a/src/app/room/components/RevealingAnswers.component.tsx
+++ b/src/app/room/components/RevealingAnswers.component.tsx
@@ -2,7 +2,9 @@ import React, { memo } from "react";
 import { Room, TopicFeedbackRating } from "@/types";
 import { useRevealingAnswersPresenter } from "./RevealingAnswers.presenter";
 import { FacilitationSuggestions } from "./FacilitationSuggestions.component";
+import { ReactionBar } from "./ReactionBar.component";
 import { useFacilitation } from "../hooks/useFacilitation";
+import { useReactions } from "@/hooks/useReactions";
 
 interface RevealingAnswersViewProps {
   room: Room;
@@ -12,6 +14,7 @@ interface RevealingAnswersViewProps {
 export const RevealingAnswersView = memo(({ room, currentUserId }: RevealingAnswersViewProps) => {
   const {
     currentTopicContent,
+    currentGameRoundId,
     allAnswers,
     hostJudgment,
     isHost,
@@ -34,6 +37,12 @@ export const RevealingAnswersView = memo(({ room, currentUserId }: RevealingAnsw
     generateSuggestions,
     clearSuggestions,
   } = useFacilitation();
+
+  const { displayReactions, sendReaction, cooldown } = useReactions(
+    currentGameRoundId,
+    currentUserId,
+    room.participants.find((p) => p.id === currentUserId)?.name ?? null
+  );
 
   const handleGenerateFacilitation = async () => {
     if (!currentTopicContent || !room.code) return;
@@ -163,6 +172,13 @@ export const RevealingAnswersView = memo(({ room, currentUserId }: RevealingAnsw
           })}
         </div>
       </div>
+
+      {/* リアクション */}
+      <ReactionBar
+        displayReactions={displayReactions}
+        sendReaction={sendReaction}
+        cooldown={cooldown}
+      />
 
       {/* ファシリテーション提案 */}
       <FacilitationSuggestions

--- a/src/hooks/useReactions.test.ts
+++ b/src/hooks/useReactions.test.ts
@@ -1,0 +1,101 @@
+import { renderHook, act } from '@testing-library/react';
+import { useReactions } from './useReactions';
+
+jest.mock('@/lib/reactionService', () => ({
+  subscribeToReactions: jest.fn(),
+  sendReaction: jest.fn(),
+}));
+
+describe('useReactions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('gameRoundIdがない場合はリアクションを購読しない', () => {
+    const { result } = renderHook(() => useReactions(null, 'user1', 'ぺいじゅん'));
+
+    expect(result.current.displayReactions).toEqual([]);
+    expect(result.current.cooldown).toBe(false);
+  });
+
+  it('初期状態ではdisplayReactionsが空でcooldownがfalse', () => {
+    const { subscribeToReactions } = require('@/lib/reactionService');
+    (subscribeToReactions as jest.Mock).mockReturnValue(jest.fn());
+
+    const { result } = renderHook(() => useReactions('round1', 'user1', 'ぺいじゅん'));
+
+    expect(result.current.displayReactions).toEqual([]);
+    expect(result.current.cooldown).toBe(false);
+  });
+
+  it('sendReactionを呼び出すとcooldownがtrueになる', async () => {
+    const { subscribeToReactions, sendReaction } = require('@/lib/reactionService');
+    (subscribeToReactions as jest.Mock).mockReturnValue(jest.fn());
+    (sendReaction as jest.Mock).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useReactions('round1', 'user1', 'ぺいじゅん'));
+
+    await act(async () => {
+      await result.current.sendReaction('😂');
+    });
+
+    expect(result.current.cooldown).toBe(true);
+  });
+
+  it('クールダウン中はsendReactionが呼ばれない', async () => {
+    const { subscribeToReactions, sendReaction } = require('@/lib/reactionService');
+    (subscribeToReactions as jest.Mock).mockReturnValue(jest.fn());
+    (sendReaction as jest.Mock).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useReactions('round1', 'user1', 'ぺいじゅん'));
+
+    await act(async () => {
+      await result.current.sendReaction('😂');
+    });
+
+    // クールダウン中に再度送信
+    await act(async () => {
+      await result.current.sendReaction('👏');
+    });
+
+    expect(sendReaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('1500ms後にcooldownがfalseに戻る', async () => {
+    const { subscribeToReactions, sendReaction } = require('@/lib/reactionService');
+    (subscribeToReactions as jest.Mock).mockReturnValue(jest.fn());
+    (sendReaction as jest.Mock).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useReactions('round1', 'user1', 'ぺいじゅん'));
+
+    await act(async () => {
+      await result.current.sendReaction('😂');
+    });
+
+    expect(result.current.cooldown).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+
+    expect(result.current.cooldown).toBe(false);
+  });
+
+  it('userId・userNameがない場合はリアクションを送信しない', async () => {
+    const { subscribeToReactions, sendReaction } = require('@/lib/reactionService');
+    (subscribeToReactions as jest.Mock).mockReturnValue(jest.fn());
+
+    const { result } = renderHook(() => useReactions('round1', null, null));
+
+    await act(async () => {
+      await result.current.sendReaction('😂');
+    });
+
+    expect(sendReaction).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useReactions.ts
+++ b/src/hooks/useReactions.ts
@@ -14,6 +14,8 @@ export function useReactions(
   const [displayReactions, setDisplayReactions] = useState<DisplayReaction[]>([]);
   const [cooldown, setCooldown] = useState(false);
   const seenReactionIds = useRef<Set<string>>(new Set());
+  const displayTimeoutsRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set());
+  const cooldownTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     if (!gameRoundId) return;
@@ -40,9 +42,11 @@ export function useReactions(
             { displayId, emoji: reaction.emoji, fromUserName: reaction.fromUserName, x },
           ]);
 
-          setTimeout(() => {
+          const timeoutId = setTimeout(() => {
             setDisplayReactions((prev) => prev.filter((r) => r.displayId !== displayId));
+            displayTimeoutsRef.current.delete(timeoutId);
           }, REACTION_DISPLAY_DURATION);
+          displayTimeoutsRef.current.add(timeoutId);
         });
       });
     };
@@ -52,8 +56,16 @@ export function useReactions(
     return () => {
       isMounted = false;
       unsubscribe?.();
+      displayTimeoutsRef.current.forEach(clearTimeout);
+      displayTimeoutsRef.current.clear();
     };
   }, [gameRoundId]);
+
+  useEffect(() => {
+    return () => {
+      if (cooldownTimeoutRef.current) clearTimeout(cooldownTimeoutRef.current);
+    };
+  }, []);
 
   const sendReaction = useCallback(
     async (emoji: string) => {
@@ -66,7 +78,11 @@ export function useReactions(
       } catch (error) {
         console.error("リアクションの送信に失敗しました:", error);
       } finally {
-        setTimeout(() => setCooldown(false), COOLDOWN_DURATION);
+        if (cooldownTimeoutRef.current) clearTimeout(cooldownTimeoutRef.current);
+        cooldownTimeoutRef.current = setTimeout(() => {
+          setCooldown(false);
+          cooldownTimeoutRef.current = null;
+        }, COOLDOWN_DURATION);
       }
     },
     [gameRoundId, currentUserId, currentUserName, cooldown]

--- a/src/hooks/useReactions.ts
+++ b/src/hooks/useReactions.ts
@@ -1,0 +1,72 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { DisplayReaction } from "@/types";
+
+const REACTION_DISPLAY_DURATION = 3000;
+const COOLDOWN_DURATION = 1500;
+
+export const REACTION_EMOJIS = ["😂", "👏", "😮", "🔥", "👍"];
+
+export function useReactions(
+  gameRoundId: string | null,
+  currentUserId: string | null,
+  currentUserName: string | null
+) {
+  const [displayReactions, setDisplayReactions] = useState<DisplayReaction[]>([]);
+  const [cooldown, setCooldown] = useState(false);
+  const seenReactionIds = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!gameRoundId) return;
+
+    seenReactionIds.current = new Set();
+
+    let unsubscribe: (() => void) | undefined;
+
+    const setup = async () => {
+      const { subscribeToReactions } = await import("@/lib/reactionService");
+      unsubscribe = subscribeToReactions(gameRoundId, (reactions) => {
+        reactions.forEach((reaction) => {
+          if (seenReactionIds.current.has(reaction.id)) return;
+          seenReactionIds.current.add(reaction.id);
+
+          const displayId = `${reaction.id}-${Date.now()}`;
+          const x = Math.floor(Math.random() * 80) + 10;
+
+          setDisplayReactions((prev) => [
+            ...prev,
+            { displayId, emoji: reaction.emoji, fromUserName: reaction.fromUserName, x },
+          ]);
+
+          setTimeout(() => {
+            setDisplayReactions((prev) => prev.filter((r) => r.displayId !== displayId));
+          }, REACTION_DISPLAY_DURATION);
+        });
+      });
+    };
+
+    setup();
+
+    return () => {
+      unsubscribe?.();
+    };
+  }, [gameRoundId]);
+
+  const sendReaction = useCallback(
+    async (emoji: string) => {
+      if (!gameRoundId || !currentUserId || !currentUserName || cooldown) return;
+
+      setCooldown(true);
+      try {
+        const { sendReaction: sendReactionService } = await import("@/lib/reactionService");
+        await sendReactionService(gameRoundId, currentUserId, currentUserName, emoji);
+      } catch (error) {
+        console.error("リアクションの送信に失敗しました:", error);
+      } finally {
+        setTimeout(() => setCooldown(false), COOLDOWN_DURATION);
+      }
+    },
+    [gameRoundId, currentUserId, currentUserName, cooldown]
+  );
+
+  return { displayReactions, sendReaction, cooldown };
+}

--- a/src/hooks/useReactions.ts
+++ b/src/hooks/useReactions.ts
@@ -21,9 +21,12 @@ export function useReactions(
     seenReactionIds.current = new Set();
 
     let unsubscribe: (() => void) | undefined;
+    let isMounted = true;
 
     const setup = async () => {
       const { subscribeToReactions } = await import("@/lib/reactionService");
+      // アンマウント済みの場合はリスナーを登録しない
+      if (!isMounted) return;
       unsubscribe = subscribeToReactions(gameRoundId, (reactions) => {
         reactions.forEach((reaction) => {
           if (seenReactionIds.current.has(reaction.id)) return;
@@ -47,6 +50,7 @@ export function useReactions(
     setup();
 
     return () => {
+      isMounted = false;
       unsubscribe?.();
     };
   }, [gameRoundId]);

--- a/src/hooks/useReactions.ts
+++ b/src/hooks/useReactions.ts
@@ -1,8 +1,8 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { DisplayReaction } from "@/types";
 
-const REACTION_DISPLAY_DURATION = 3000;
-const COOLDOWN_DURATION = 1500;
+const REACTION_DISPLAY_DURATION = 5000;
+const COOLDOWN_DURATION = 500;
 
 export const REACTION_EMOJIS = ["😂", "👏", "😮", "🔥", "👍"];
 

--- a/src/hooks/useReactions.ts
+++ b/src/hooks/useReactions.ts
@@ -29,10 +29,14 @@ export function useReactions(
       const { subscribeToReactions } = await import("@/lib/reactionService");
       // アンマウント済みの場合はリスナーを登録しない
       if (!isMounted) return;
+      let isFirstSnapshot = true;
       unsubscribe = subscribeToReactions(gameRoundId, (reactions) => {
         reactions.forEach((reaction) => {
           if (seenReactionIds.current.has(reaction.id)) return;
           seenReactionIds.current.add(reaction.id);
+
+          // 初回スナップショット（ページロード時の既存データ）は表示しない
+          if (isFirstSnapshot) return;
 
           const displayId = `${reaction.id}-${Date.now()}`;
           const x = Math.floor(Math.random() * 80) + 10;
@@ -48,16 +52,18 @@ export function useReactions(
           }, REACTION_DISPLAY_DURATION);
           displayTimeoutsRef.current.add(timeoutId);
         });
+        isFirstSnapshot = false;
       });
     };
 
     setup();
 
+    const displayTimeouts = displayTimeoutsRef.current;
     return () => {
       isMounted = false;
       unsubscribe?.();
-      displayTimeoutsRef.current.forEach(clearTimeout);
-      displayTimeoutsRef.current.clear();
+      displayTimeouts.forEach(clearTimeout);
+      displayTimeouts.clear();
     };
   }, [gameRoundId]);
 

--- a/src/lib/gameEffects.ts
+++ b/src/lib/gameEffects.ts
@@ -265,6 +265,24 @@ export function injectGameAnimations(): void {
     .animate-no-match-text {
       animation: no-match-text-wobble 2s ease-out;
     }
+
+    @keyframes reaction-float {
+      0% {
+        transform: translateY(0) scale(1);
+        opacity: 1;
+      }
+      70% {
+        opacity: 1;
+      }
+      100% {
+        transform: translateY(-80px) scale(1.3);
+        opacity: 0;
+      }
+    }
+
+    .animate-reaction-float {
+      animation: reaction-float 3s ease-out forwards;
+    }
   `;
   
   document.head.appendChild(style);

--- a/src/lib/gameEffects.ts
+++ b/src/lib/gameEffects.ts
@@ -281,7 +281,7 @@ export function injectGameAnimations(): void {
     }
 
     .animate-reaction-float {
-      animation: reaction-float 1.5s ease-out forwards;
+      animation: reaction-float 5s ease-out forwards;
     }
   `;
   

--- a/src/lib/gameEffects.ts
+++ b/src/lib/gameEffects.ts
@@ -268,20 +268,20 @@ export function injectGameAnimations(): void {
 
     @keyframes reaction-float {
       0% {
-        transform: translateY(0) scale(1);
+        transform: translateY(0);
         opacity: 1;
       }
       70% {
         opacity: 1;
       }
       100% {
-        transform: translateY(-80px) scale(1.3);
+        transform: translateY(-200px);
         opacity: 0;
       }
     }
 
     .animate-reaction-float {
-      animation: reaction-float 3s ease-out forwards;
+      animation: reaction-float 1.5s ease-out forwards;
     }
   `;
   

--- a/src/lib/reactionService.test.ts
+++ b/src/lib/reactionService.test.ts
@@ -1,0 +1,73 @@
+import { sendReaction, deleteReactionsForRound } from './reactionService';
+
+jest.mock('firebase/firestore', () => ({
+  collection: jest.fn(),
+  addDoc: jest.fn(),
+  serverTimestamp: jest.fn(() => ({ seconds: 0 })),
+  onSnapshot: jest.fn(),
+  query: jest.fn(),
+  orderBy: jest.fn(),
+  writeBatch: jest.fn(),
+  getDocs: jest.fn(),
+  Timestamp: { fromDate: jest.fn() },
+}));
+
+jest.mock('@/lib/firebase', () => ({ db: {} }));
+
+describe('reactionService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('sendReaction', () => {
+    it('指定した絵文字でリアクションをFirestoreに保存する', async () => {
+      const { addDoc, collection } = await import('firebase/firestore');
+      const mockAddDoc = addDoc as jest.Mock;
+      const mockCollection = collection as jest.Mock;
+      mockCollection.mockReturnValue('reactions-ref');
+      mockAddDoc.mockResolvedValue({ id: 'reaction1' });
+
+      await sendReaction('round1', 'user1', 'ぺいじゅん', '😂');
+
+      expect(mockAddDoc).toHaveBeenCalledWith(
+        'reactions-ref',
+        expect.objectContaining({
+          emoji: '😂',
+          fromUserId: 'user1',
+          fromUserName: 'ぺいじゅん',
+        })
+      );
+    });
+  });
+
+  describe('deleteReactionsForRound', () => {
+    it('リアクションが存在しない場合は何もしない', async () => {
+      const { getDocs, writeBatch } = await import('firebase/firestore');
+      const mockGetDocs = getDocs as jest.Mock;
+      const mockWriteBatch = writeBatch as jest.Mock;
+      mockGetDocs.mockResolvedValue({ empty: true, docs: [] });
+
+      await deleteReactionsForRound('round1');
+
+      expect(mockWriteBatch).not.toHaveBeenCalled();
+    });
+
+    it('リアクションが存在する場合はバッチ削除する', async () => {
+      const { getDocs, writeBatch } = await import('firebase/firestore');
+      const mockCommit = jest.fn().mockResolvedValue(undefined);
+      const mockDelete = jest.fn();
+      const mockGetDocs = getDocs as jest.Mock;
+      const mockWriteBatch = writeBatch as jest.Mock;
+      mockWriteBatch.mockReturnValue({ delete: mockDelete, commit: mockCommit });
+      mockGetDocs.mockResolvedValue({
+        empty: false,
+        docs: [{ ref: 'ref1' }, { ref: 'ref2' }],
+      });
+
+      await deleteReactionsForRound('round1');
+
+      expect(mockDelete).toHaveBeenCalledTimes(2);
+      expect(mockCommit).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/lib/reactionService.ts
+++ b/src/lib/reactionService.ts
@@ -1,0 +1,65 @@
+import {
+  collection,
+  addDoc,
+  serverTimestamp,
+  onSnapshot,
+  query,
+  orderBy,
+  writeBatch,
+  getDocs,
+  Timestamp,
+} from "firebase/firestore";
+import { db } from "./firebase";
+import { Reaction } from "@/types";
+
+export async function sendReaction(
+  gameRoundId: string,
+  fromUserId: string,
+  fromUserName: string,
+  emoji: string
+): Promise<void> {
+  await addDoc(collection(db, "gameRounds", gameRoundId, "reactions"), {
+    emoji,
+    fromUserId,
+    fromUserName,
+    createdAt: serverTimestamp(),
+  });
+}
+
+export function subscribeToReactions(
+  gameRoundId: string,
+  callback: (_reactions: Reaction[]) => void
+): () => void {
+  const reactionsRef = collection(db, "gameRounds", gameRoundId, "reactions");
+  const q = query(reactionsRef, orderBy("createdAt", "asc"));
+
+  return onSnapshot(q, (snapshot) => {
+    const reactions: Reaction[] = snapshot.docs.map((doc) => {
+      const data = doc.data();
+      return {
+        id: doc.id,
+        emoji: data.emoji,
+        fromUserId: data.fromUserId,
+        fromUserName: data.fromUserName,
+        createdAt: data.createdAt instanceof Timestamp ? data.createdAt.toDate() : new Date(),
+      };
+    });
+    callback(reactions);
+  });
+}
+
+export async function deleteReactionsForRound(gameRoundId: string): Promise<void> {
+  try {
+    const reactionsRef = collection(db, "gameRounds", gameRoundId, "reactions");
+    const snapshot = await getDocs(reactionsRef);
+    if (snapshot.empty) return;
+
+    const batch = writeBatch(db);
+    snapshot.docs.forEach((doc) => {
+      batch.delete(doc.ref);
+    });
+    await batch.commit();
+  } catch (error) {
+    console.error("deleteReactionsForRound error:", error);
+  }
+}

--- a/src/lib/roomService.ts
+++ b/src/lib/roomService.ts
@@ -552,8 +552,11 @@ export async function startNextRound(roomId: string): Promise<void> {
     const nextRound = currentTopic ? currentTopic.round + 1 : 2;
     
     
-    // 前回のゲームラウンドを完了状態に更新
+    // 前回のゲームラウンドを完了状態に更新・リアクション削除
     if (roomData.currentGameRoundId) {
+      const { deleteReactionsForRound } = await import('@/lib/reactionService');
+      await deleteReactionsForRound(roomData.currentGameRoundId);
+
       const { completeGameRound } = await import('@/lib/gameRoundService');
       
       // 現在のゲームラウンドから判定を取得

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -79,6 +79,22 @@ export interface GameRound {
   createdAt: Date;
 }
 
+// Reaction types
+export interface Reaction {
+  id: string;
+  emoji: string;
+  fromUserId: string;
+  fromUserName: string;
+  createdAt: Date;
+}
+
+export interface DisplayReaction {
+  displayId: string;
+  emoji: string;
+  fromUserName: string;
+  x: number; // 10〜90の表示位置（%）
+}
+
 // Topic feedback types
 export interface TopicFeedback {
   id: string;


### PR DESCRIPTION
closes #29

## 変更内容

回答公開中（revealing状態）に参加者がスタンプを送り合えるリアクション機能を追加しました。

## 実装詳細

- **`Reaction` / `DisplayReaction` 型**を追加
- **`reactionService.ts`**: 送信・Firestoreリアルタイム購読・ラウンド終了時バッチ削除
- **`useReactions` hook**: クールダウン制御（1.5秒）・表示アニメーション管理（3秒でフェードアウト）
- **`ReactionBar` コンポーネント**: 😂👏😮🔥👍 の送信ボタン + フローティングアニメーション
- **`RevealingAnswers`** に組み込み
- **Firestoreルール**: `gameRounds/{id}/reactions` サブコレクションのバリデーション追加
- **`startNextRound`** 時に前ラウンドのリアクションをバッチ削除

## テスト

- `reactionService.test.ts`: 送信・削除のユニットテスト
- `useReactions.test.ts`: クールダウン・送信制御のユニットテスト
- 288テスト全パス